### PR TITLE
fix google sign in version

### DIFF
--- a/GoogleSignInPlugin/Assets/GoogleSignIn/Editor/GoogleSignInDependencies.xml
+++ b/GoogleSignInPlugin/Assets/GoogleSignIn/Editor/GoogleSignInDependencies.xml
@@ -12,7 +12,7 @@
 
   <!-- iOS Cocoapod dependencies can be specified by each iosPod element. -->
   <iosPods>
-    <iosPod name="GoogleSignIn" version=">= 6.0.2" bitcodeEnabled="false"
+    <iosPod name="GoogleSignIn" version="= 6.2.4" bitcodeEnabled="false"
         minTargetSdk="6.0">
     </iosPod>
   </iosPods>


### PR DESCRIPTION
Current version gives error after GoogleSignIn 7.0.0 released. So I fixed the version to 6.2.4.